### PR TITLE
Add kt instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,16 @@ allprojects {
 }
 
 // App-level build.gradle file:
+
+// If using Kotlin:
+apply plugin: 'kotlin-kapt'
+
 dependencies {
   compile 'com.blueapron:marinator:1.0.0'
   annotationProcessor 'com.blueapron:marinator-processor:1.0.0'
+
+  // If using Kotlin:
+  kapt 'com.blueapron:marinator-processor:1.0.0'
 }
 ```
 


### PR DESCRIPTION
I expect a lot of kotlin users wanting to use this library, so it's probably a good idea to add instructions on how to set up the annotation processor using the `kapt` plugin.