### PR TITLE
Adding a sort to guarantee stable parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,38 @@ License
 -------
 
 Marinator is licensed under the MIT license. See [the license](LICENSE) for details.
+
+Third-Party Licenses
+-------
+
+#### Guava
+
+Copyright 2011, Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+#### JavaPoet
+
+Copyright 2015 Square, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ allprojects {
 apply plugin: 'kotlin-kapt'
 
 dependencies {
-  compile 'com.github.blueapron.marinator:marinator:1.0.2'
-  annotationProcessor 'com.github.blueapron.marinator:marinator-processor:1.0.2'
+  compile 'com.github.blueapron.marinator:marinator:1.0.3'
+  annotationProcessor 'com.github.blueapron.marinator:marinator-processor:1.0.3'
 
   // If using Kotlin:
-  kapt 'com.github.blueapron.marinator:marinator-processor:1.0.2'
+  kapt 'com.github.blueapron.marinator:marinator-processor:1.0.3'
 }
 ```
 

--- a/marinator-tests/src/main/java/com/blueapron/marinator/test/components/BananaComponent.java
+++ b/marinator-tests/src/main/java/com/blueapron/marinator/test/components/BananaComponent.java
@@ -1,0 +1,14 @@
+package com.blueapron.marinator.test.components;
+
+import com.blueapron.marinator.Injector;
+import com.blueapron.marinator.test.models.BananaObject;
+
+/**
+ * Component to test injection.
+ */
+public class BananaComponent {
+    @Injector
+    public void inject(BananaObject obj) {
+        obj.injected = true;
+    }
+}

--- a/marinator-tests/src/main/java/com/blueapron/marinator/test/components/ZebraComponent.java
+++ b/marinator-tests/src/main/java/com/blueapron/marinator/test/components/ZebraComponent.java
@@ -1,0 +1,14 @@
+package com.blueapron.marinator.test.components;
+
+import com.blueapron.marinator.Injector;
+import com.blueapron.marinator.test.models.ZebraObject;
+
+/**
+ * Component to test injection.
+ */
+public class ZebraComponent {
+    @Injector
+    public void inject(ZebraObject obj) {
+        obj.injected = true;
+    }
+}

--- a/marinator-tests/src/main/java/com/blueapron/marinator/test/models/BananaObject.java
+++ b/marinator-tests/src/main/java/com/blueapron/marinator/test/models/BananaObject.java
@@ -1,0 +1,8 @@
+package com.blueapron.marinator.test.models;
+
+/**
+ * Target for injection.
+ */
+public class BananaObject {
+    public boolean injected = false;
+}

--- a/marinator-tests/src/main/java/com/blueapron/marinator/test/models/ZebraObject.java
+++ b/marinator-tests/src/main/java/com/blueapron/marinator/test/models/ZebraObject.java
@@ -1,0 +1,8 @@
+package com.blueapron.marinator.test.models;
+
+/**
+ * Target for injection.
+ */
+public class ZebraObject {
+    public boolean injected = false;
+}

--- a/marinator-tests/src/test/java/com/blueapron/marinator/test/MarinatorTest.java
+++ b/marinator-tests/src/test/java/com/blueapron/marinator/test/MarinatorTest.java
@@ -3,10 +3,16 @@ package com.blueapron.marinator.test;
 import com.blueapron.marinator.Marinator;
 import com.blueapron.marinator.generated.MarinadeHelper;
 import com.blueapron.marinator.test.components.AppComponent;
+import com.blueapron.marinator.test.components.BananaComponent;
 import com.blueapron.marinator.test.components.NetComponent;
+import com.blueapron.marinator.test.components.ZebraComponent;
 import com.blueapron.marinator.test.models.AppObject1;
+import com.blueapron.marinator.test.models.AppObject2;
+import com.blueapron.marinator.test.models.BananaObject;
 import com.blueapron.marinator.test.models.NetObject1;
+import com.blueapron.marinator.test.models.NetObject2;
 import com.blueapron.marinator.test.models.NonInjectedObject;
+import com.blueapron.marinator.test.models.ZebraObject;
 
 import org.junit.Test;
 
@@ -22,8 +28,10 @@ public class MarinatorTest {
     public void testInjectors() {
         // Create the components and prepare the Marinade.
         AppComponent appComponent = new AppComponent();
+        BananaComponent bananaComponent = new BananaComponent();
         NetComponent netComponent = new NetComponent();
-        MarinadeHelper.prepare(appComponent, netComponent);
+        ZebraComponent zebraComponent = new ZebraComponent();
+        MarinadeHelper.prepare(appComponent, bananaComponent, netComponent, zebraComponent);
 
         // Now create some objects and inject them.
         AppObject1 app1 = new AppObject1();
@@ -31,20 +39,30 @@ public class MarinatorTest {
         Marinator.inject(app1);
         assertThat(app1.injected).isTrue();
 
-        AppObject1 app2 = new AppObject1();
+        AppObject2 app2 = new AppObject2();
         assertThat(app2.injected).isFalse();
         Marinator.inject(app2);
         assertThat(app2.injected).isTrue();
+
+        BananaObject banana = new BananaObject();
+        assertThat(banana.injected).isFalse();
+        Marinator.inject(banana);
+        assertThat(banana.injected).isTrue();
 
         NetObject1 net1 = new NetObject1();
         assertThat(net1.injected).isFalse();
         Marinator.inject(net1);
         assertThat(net1.injected).isTrue();
 
-        NetObject1 net2 = new NetObject1();
+        NetObject2 net2 = new NetObject2();
         assertThat(net2.injected).isFalse();
         Marinator.inject(net2);
         assertThat(net2.injected).isTrue();
+
+        ZebraObject zebra = new ZebraObject();
+        assertThat(zebra.injected).isFalse();
+        Marinator.inject(zebra);
+        assertThat(zebra.injected).isTrue();
 
         NonInjectedObject nonInjected = new NonInjectedObject();
         assertThat(nonInjected.injected).isFalse();


### PR DESCRIPTION
Marinator had a very subtle bug previously. The order of the parameters for the MarinadeHelper and the constructor were determined by file traversal order. It's possible that this is different across different build environments, which leads to compilation errors.

The fix is to sort the parameters in a deterministic order. This allows us to guarantee the order of the constructor params.

Additionally, this PR adds the correct attribution for third-party libraries used in Marinator.